### PR TITLE
Update mri_team_count_series.sql

### DIFF
--- a/mri_team_count/count_query/mri_team_count_series.sql
+++ b/mri_team_count/count_query/mri_team_count_series.sql
@@ -6,6 +6,7 @@ WITH cleanup_series AS (
 SELECT 
   mri_team_count.*,
   series.id as series_id,
+  series.nifti_md5sum as nifti_md5sum,
   series.series_number,
   series.series_description,
   series.nifti_path,


### PR DESCRIPTION
This PR adds nifti md5sum which will be used to match Freesurfer outputs to the database.